### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,6 @@ nltk>=3.8.1 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.0 # not directly required, pinned by Snyk to avoid a vulnerability
 scikit-learn>=1.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 anyio>=4.4.0 # not directly required, pinned by Snyk to avoid a vulnerability
+
+grpcio-status==1.62.2
+grpcio-tools==1.62.2


### PR DESCRIPTION
A freshly installed text-generation-webui 1.8 installs protobuf version 4.25.3, which pip says is incompatible with those libs.

However, this requeriments.txt will install:
- grpcio-status 1.64.1
- grpcio-tools 1.64.1

pip's dependency resolver will upgrade protobuf to version 5.27.2:

> grpcio-status 1.64.1 requires protobuf<6.0dev,>=5.26.1, but you have protobuf 4.25.3 which is incompatible. grpcio-tools 1.64.1 requires protobuf<6.0dev,>=5.26.1, but you have protobuf 4.25.3 which is incompatible.

which will break tensorboard 2.17.0:

> tensorboard 2.17.0 requires protobuf!=4.24.0,<5.0.0,>=3.19.6, but you have protobuf 5.27.2 which is incompatible.

Version 1.62.2 of these libraries will not break neither of them (version 1.63.0 onwards requires protobuf >=5.26.1)