### PR TITLE
Update commandhandler.py

### DIFF
--- a/commandhandler.py
+++ b/commandhandler.py
@@ -102,10 +102,20 @@ class CommandHandler():
 
                     if is_url == False:
                         if os.path.exists(file):
-                            print("file exist")
-                            content = file_load_handler.read_file(file)
-                            self.command_output["FILE_LOAD"] = f"FILE_LOAD: {content}"
-
+                            print("Path exist")
+                            if os.path.isfile(file):
+                                print("Path leads to a file")
+                                content = file_load_handler.read_file(file)
+                                self.command_output["FILE_LOAD"] = f"FILE_LOAD: {content}"
+                            elif os.path.isdir(file):
+                                directory = file
+                                print("Path leads to a directory. This will skip adding to content due to likelihood of extreme length.")
+                                count = 0
+                                for file in os.listdir(directory): 
+                                    path = directory + file
+                                    file_load_handler.read_file(path)
+                                    count += 1
+                                self.command_output["FILE_LOAD"] = f"FILE_LOAD: Successfully ingested {count} total documents."
                         else:
                             print("File does not exist")
                             self.command_output["FILE_LOAD"] = f"FILE_LOAD: File doesn't exist"


### PR DESCRIPTION
Fixed issue with FILE_LOAD command when given a directory rather than a single file causing a crash instead of working as expected. The downside is that by doing it this way, there's no way to avoid sending a message to the bot. This can cause it's message count to change, and create memories you may not want, due to the way the addon is structured. It also doesn't send anything of use to the bot back through the command_output, only a count of ingested documents. This is required since even a few ingested documents could vastly go over context limits.